### PR TITLE
Translation resolver improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ environment:
 ### Integration with Kdyby\Translation
 
 This feature provides automatic evaluation of the locale parameter for `Kdyby\Translation` based on profile settings in the extension. 
+Default profile's language can be used if setting `translations.useDefault` is set to `TRUE`.
+If is this setting set to `FALSE` default language will not be used and other resolvers will be invoked.
 Also if you change language via method `\SixtyEightPublishers\Application\Environment\ActiveProfile::changeLanguage()`, locale in Translator is changed too.
 
 ```yml
 environment:
-	translations: yes
+	translations:
+	    enable: yes
+	    useDefault: no
 ```
 
 ## Rules for contributing

--- a/src/Environment/DI/EnvironmentExtension.php
+++ b/src/Environment/DI/EnvironmentExtension.php
@@ -26,7 +26,10 @@ class EnvironmentExtension extends CompilerExtension
 	private $defaults = [
 		'debugger' => FALSE,
 		'localeDomain' => FALSE,
-		'translations' => FALSE,
+		'translations' => [
+			'enable' => FALSE,
+			'useDefault' => FALSE,
+		],
 		'mode' => 'tolerant',
 		'profile' => [],
 	];
@@ -71,7 +74,7 @@ class EnvironmentExtension extends CompilerExtension
 			]);
 		}
 
-		if ($config['translations']) {
+		if ($config['translations']['enable']) {
 			$extensions = $this->compiler->getExtensions($extensionClass = '\Kdyby\Translation\DI\TranslationExtension');
 			if (empty($extensions)) {
 				throw new AssertionException('You should register \'' . $extensionClass . '\' before \'' . get_class($this) . '\'.', E_USER_NOTICE);
@@ -80,7 +83,10 @@ class EnvironmentExtension extends CompilerExtension
 			$extension = $extensions[array_keys($extensions)[0]];
 
 			$builder->addDefinition($this->prefix('translationResolver'))
-				->setType(ProfileStorageResolver::class);
+				->setType(ProfileStorageResolver::class)
+				->setArguments([
+					'useDefault' => (bool) $config['translations']['useDefault'],
+				]);
 
 			$chain = $builder->getDefinition($extension->name . '.userLocaleResolver');
 			$chain->addSetup('addResolver', [

--- a/src/Environment/Translation/ProfileStorageResolver.php
+++ b/src/Environment/Translation/ProfileStorageResolver.php
@@ -11,15 +11,20 @@ class ProfileStorageResolver implements IUserLocaleResolver
 	/** @var \SixtyEightPublishers\Application\Environment\IProfileStorage  */
 	private $storage;
 
+	/** @var bool  */
+	private $useDefault = FALSE;
+
 	/** @var bool */
 	private $lock = FALSE;
 
 	/**
 	 * @param \SixtyEightPublishers\Application\Environment\IProfileStorage $storage
+	 * @param bool                                                          $useDefault
 	 */
-	public function __construct(IProfileStorage $storage)
+	public function __construct(IProfileStorage $storage, bool $useDefault = FALSE)
 	{
 		$this->storage = $storage;
+		$this->useDefault = $useDefault;
 	}
 
 	/**
@@ -29,7 +34,7 @@ class ProfileStorageResolver implements IUserLocaleResolver
 	 */
 	public function resolve(Translator $translator)
 	{
-		$locale = $this->storage->getProfile()->getLanguage(FALSE);
+		$locale = $this->storage->getProfile()->getLanguage($this->useDefault);
 		if (is_null($locale) && !$this->lock) {
 			$this->lock = TRUE;
 			if (NULL !== ($newLocale = $translator->getLocale())) {


### PR DESCRIPTION
- added setting `translations.enable` instead of generic `translations`
- added setting `translations.useDefault`